### PR TITLE
Fix: use PIL.Image.resize instead of np.resize for proper pattern sca…

### DIFF
--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -52,8 +52,8 @@ def generate_waffle_pattern(args):
             pattern = pattern.convert("L")
         else:
             pattern = pattern.convert("RGB")
+        pattern = pattern.resize((args.image_size, args.image_size), Image.BILINEAR)
         pattern = np.array(pattern)
-        pattern = np.resize(pattern, (args.image_size, args.image_size, args.num_channels))
         base_patterns.append(pattern)
     trigger_set = []
     trigger_set_labels = []


### PR DESCRIPTION
## Related Issue
Fixes #1

## Summary
This pull request addresses an image resizing issue in `generate_waffle_pattern()` within `watermark.py`. The original implementation uses `np.resize()` which incorrectly truncates or repeats image data when resizing from original pattern size (e.g., 423x389x3) to target size (e.g., 32x32x3). This leads to misleading experimental results and poor watermark detection accuracy when regenerating trigger sets.

## Root Cause
Line 56 of `watermark.py`:
```python
pattern = np.resize(pattern, (args.image_size, args.image_size, args.num_channels))
```
This approach forcibly reshapes arrays without proper interpolation, resulting in loss of pattern integrity.

## Fix
Replaced with:
```python
pattern = pattern.resize((args.image_size, args.image_size), Image.BILINEAR)
pattern = np.array(pattern)
```
This uses PIL's proper resizing with bilinear interpolation to preserve image features.

## Suggestion
Consider updating the evaluation methodology to avoid potential data leakage between training and testing sets.

Let me know if any changes are needed. Happy to help!